### PR TITLE
Discuss markdown extensions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ style it with [CSS](resume.css), output to [HTML](resume.html) and
  3. Edit [resume.md](resume.md) (the placeholder text is taken with thanks from the 
     [JSON Resume Project](https://jsonresume.org/themes/))
 
- 4. Run `make resume` to build resume.html and resume.pdf.
+ 4. Run `make resume` to build resume.html and resume.pdf. If `make` is not
+    available (e.g. Windows) run `python resume.py` then `weasyprint resume.html
+    resume.pdf` instead.
+
+Optionally, run `make watch` while you are working on your resume to rebuild it
+whenever resume.md or resume.css change (requires
+[entr](http://eradman.com/entrproject/)).
 
 ## Customization
 
@@ -36,30 +42,21 @@ but CSS gives you a lot of flexibility. See, e.g. [The Tech Resume
 Inside-Out](https://www.thetechinterview.com/) for good advice about what a
 resume should look like (and what it should say).
 
-Because the source is plain markdown and python-markdown is a very bare bones
-markdown compiler, elements cannot be tagged with ids or classes in the markdown
-source. If you need more control over the HTML, take a look at
-[kramdown](https://kramdown.gettalong.org/syntax.html). I chose not to use it
-for this project to avoid a non-python dependency.
-
 Change the appearance of the PDF version (without affecting the HTML version) by
-adding rules under the `@media print` CSS selector. 
+adding rules under the `@media print` CSS selector.
 
 Change the margins and paper size of the PDF version by editing the [`@page` CSS
 rule](https://developer.mozilla.org/en-US/docs/Web/CSS/%40page/size).
 
-If you make a resume.css that you like, please submit a pull request. I'd be
-happy to collect these.
+[python-markdown](https://python-markdown.github.io/) is by default a very basic
+markdown compiler, but it has a number of optional extensions that you may want
+to enable (by adding to [the list of extensions
+here](https://github.com/mikepqr/resume.md/blob/5d99e02bf65ff6a2a0ccd18c1a0255c26ec59377/resume.py#L41)).
+<code><a
+href="https://python-markdown.github.io/extensions/attr_list/">attr_list</a></code>
+in particular may by useful if you are editing the CSS.
 
 ## Tips
-
-If you don't have `make` on your system (e.g. Windows) then you can replicate
-`make resume` by running `python resume.py` then `weasyprint resume.html
-resume.pdf`.
-
-Run `make watch` while you are working on your resume to rebuild it whenever
-resume.md or resume.css change (requires
-[entr](http://eradman.com/entrproject/)).
 
 The simplest way to maintain multiple versions of your resume is to comment bits
 of text in or out based on the audience. This can be done with standard HTML

--- a/resume.css
+++ b/resume.css
@@ -54,7 +54,7 @@ h1 + ul > li {
     white-space: pre;
     list-style-type: none;
 }
-h1 + ul > li:after { 
+h1 + ul > li:after {
     content: "  \2022  ";
 }
 h1 + ul > li:last-child:after {

--- a/resume.md
+++ b/resume.md
@@ -33,7 +33,7 @@ compression.
 ### <span>Teacher, CoderDojo</span> <span>July 2013 -- Dec 2013</span>
 
 Global movement of free coding clubs for young people.
- 
+
  - Awarded 'Teacher of the Month'
 
 ## Projects


### PR DESCRIPTION
Closes #9 (the original goal of that issue is not possible because "There is no way to use an attribute list to define attributes on implied elements, including but not limited to the following: ul, ol, dl, table, thead, tbody, and tr").

Also delete some trailing whitespace and move the non-make instructions up.