### PR TITLE
Added Separate Function for win32

### DIFF
--- a/resume.py
+++ b/resume.py
@@ -217,7 +217,7 @@ def write_html(html: str, prefix: str = "resume") -> None:
         logging.info(f"Wrote {htmlfp.name}")
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "file",
@@ -258,10 +258,14 @@ if __name__ == "__main__":
     if sys.platform == "win32":
         write_html(html,prefix)
         write_pdf_win32(prefix, chrome=args.chrome_path)
-        sys.exit()
+    else:
+    
+        if not args.no_html:
+            write_html(html, prefix)
 
-    if not args.no_html:
-        write_html(html, prefix)
+        if not args.no_pdf:
+            write_pdf(html, prefix=prefix, chrome=args.chrome_path)
 
-    if not args.no_pdf:
-        write_pdf(html, prefix=prefix, chrome=args.chrome_path)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The tool now works on win32 ☺ Additionally, it should not interfere with the working of the tool on macOS and Linux. Thats because we now have two different functions - one for win32 and another for macOS/Linux
* Gotten rid of the temporary directory workflow altogether. Relying on invoking `chrome.exe` from command-line instead.
* Created a separate function for writing pdf for win32
* I cannot pass the entire HTML in base64 encoded format via the command line. I get a command too long error. So I must first create the html file and then create the pdf file from the html file.
* As a result, the args are not respected. IMHO, this is okay for now because the tool actually works now for win32 users 🤣
* So in philosophy, I am simply trying to run the below PowerShell command from Python:
`& 'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe' --headless --disable-gpu --run-all-compositor-stages-before-draw --print-to-pdf-no-header --virtual-time-budget=5000 --no-margins --print-to-pdf=C:\work\code\resume.md\resume.pdf C:\work\code\resume.md\resume.html`

Fixes mikepqr/resume.md#13
Fixes mikepqr/resume.md#14