### PR TITLE
fix: use absolute path to fix pdf output on windows

### DIFF
--- a/resume.py
+++ b/resume.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
     else:
         logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    prefix, _ = os.path.splitext(args.file)
+    prefix, _ = os.path.splitext(os.path.abspath(args.file))
 
     with open(args.file, encoding="utf-8") as mdfp:
         md = mdfp.read()


### PR DESCRIPTION
Based on user reports (see #14), Chrome PDF output to fail in some
circumstances on Windows. It doesn't fail in the CI builds, so we don't
have a true root cause. :shrug:

The fix (or at least benign change!) is to pass Chrome an absolute path
to the PDF.

Credit to #18 for this fix! I've chosen to cherry-pick that fix (that PR
also addresses a separate issue).