### PR TITLE
fix: add workaround for Windows permissions error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
     workflow_dispatch:
     pull_request:
     push:
-        branches:
-            main
 
 jobs:
   build:
@@ -21,7 +19,7 @@ jobs:
     - name: Install markdown
       run: pip3 install markdown
     - name: Make resume
-      run: python3 resume.py
+      run: python3 resume.py --debug
     - name: Rename output
       if: ${{ matrix.os != 'windows-latest' }}
       run: |


### PR DESCRIPTION
We were getting errors like 
```
PermissionError: [WinError 5] Access is denied: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\resume.md_k098zhaj\\CrashpadMetrics-active.pma'
```
and
```
Exception ignored in: <finalize object at 0x16d9e039d60; dead> 
...
NotADirectoryError: [WinError 267] The directory name is invalid:
'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\resume.md_3aoun3f2\\CrashpadMetrics-active.pma'
```
in CI on Windows. See e.g.
https://github.com/mikepqr/resume.md/runs/5172290981 and
https://github.com/mikepqr/resume.md/runs/5172234014.

The root cause was that Chrome creates a file the python process does
not have permission to delete. See
https://github.com/puppeteer/puppeteer/issues/2778. Because
TemporaryDirectory is intended to be used as a context manager there is
no way to prevent it logging an error when cleanup fails.

The fix is to switch to the lower level tempfile.mkdtemp, and make a
good faith attempt to clean it up manually, logging failure at the debug
level (while adding a new --debug option).

A more sophisticated fix would be to backport the new
ignore_cleanup_errors option added in python 3.10
(https://github.com/python/cpython/pull/24793), but this will do.

Fixes #13