### PR TITLE
fix: resolve gpu-related warnings on linux

### DIFF
--- a/resume.py
+++ b/resume.py
@@ -126,10 +126,8 @@ def write_pdf(html: str, prefix: str = "resume", chrome: str = "") -> None:
         "--print-to-pdf-no-header",
         "--enable-logging=stderr",
         "--log-level=2",
+        "--in-process-gpu",
     ]
-    # https://bugs.chromium.org/p/chromium/issues/detail?id=737678
-    if sys.platform == "win32":
-        options.append("--disable-gpu")
 
     # Ideally we'd use tempfile.TemporaryDirectory here. We can't because
     # attempts to delete the tmpdir fail on Windows because Chrome creates a


### PR DESCRIPTION
See https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md

Apparently --disable-gpu should no longer be necessary on Windows, but
--in-process-gpu helps on linux.

Fixes #21